### PR TITLE
fix: 🐛 prefer resolved theme when available

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -16,24 +16,18 @@ const Head = () => {
 };
 
 const Logo = () => {
-  const { theme } = useTheme();
+  const { resolvedTheme, theme } = useTheme();
 
   return (
-    <>
-      {theme === "dark" ? (
-        <img
-          alt="tech2elevate"
-          style={{ height: "40px", padding: "5px" }}
-          src="/images/tech2elevate-logo-dark-mode.png"
-        />
-      ) : (
-        <img
-          alt="tech2elevate"
-          style={{ height: "40px", padding: "5px" }}
-          src="/images/tech2elevate-logo.png"
-        />
-      )}
-    </>
+    <img
+      alt="tech2elevate"
+      style={{ height: "40px", padding: "5px" }}
+      src={
+        resolvedTheme === "dark" || theme === "dark"
+          ? "/images/tech2elevate-logo-dark-mode.png"
+          : "/images/tech2elevate-logo.png"
+      }
+    />
   );
 };
 


### PR DESCRIPTION
Since `system` is the default, `theme` will be `undefined`, this allows us to leverage the resolved theme when available. In addition, I refactored to keep the image but only swap the `src`